### PR TITLE
Changes for KVM2 compatibility

### DIFF
--- a/description/config.sh
+++ b/description/config.sh
@@ -36,7 +36,19 @@ rm /root/virtualization-containers.key
 baseInsertService sshd
 baseInsertService chronyd
 
-ln -sf /lib/systemd/system/docker.service /usr/lib/systemd/system/docker.service
+mkdir -p /etc/systemd/system/docker.service.d/
+cat >> /etc/systemd/system/docker.service.d/20-extra-minikube.conf << 'EOF'
+# Extra settings that don't seem to be picked up by KVM !?
+[Unit]
+After=minikube-automount.service
+Requires=minikube-automount.service
+
+[Service]
+# DOCKER_RAMDISK disables pivot_root in Docker, using MS_MOVE instead.
+Environment=DOCKER_RAMDISK=yes
+
+LimitNOFILE=infinity
+EOF
 baseInsertService minikube-automount
 
 #======================================
@@ -119,10 +131,6 @@ ln -sf /mnt/sda1/var/lib/rkt-etc /etc/rkt
 
 ln -sf /mnt/sda1/var/log /tmp/log
 
-ln -sf /mnt/sda1/var/lib/boot2docker /var/lib/boot2docker
-ln -sf /mnt/sda1/var/lib/cni /var/lib/cni
-ln -sf /mnt/sda1/var/lib/docker /var/lib/docker
-ln -sf /mnt/sda1/var/lib/kubelet /var/lib/kubelet
 ln -sf /mnt/sda1/var/lib/localkube /var/lib/localkube
 
 #======================================


### PR DESCRIPTION
- Do not symlink `/lib/systemd/system/docker.service` as that file does
  not exist since docker-machine 0.10.0 (which means whatever version
  of external docker-machine-driver-kvm2 you end up using will not have
  that file); this causes an issue with `systemctl enable docker`.
  Instead, inline the changes we want as a systemd drop-in instead.
- Do not make a bunch of symlinks for `/var/lib/*` which will later cause
  `minikube-automount` to break (because it runs `mkdir` without `-p`).
  The `minikube-automount` script will make bind mounts anyway, which
  means they live on the data partition as intended.

Note that, for unknown reasons, using docker-machine-driver-kvm2 directly does
not work yet, as openSUSE does not seem to want to boot without a video
card.