### PR TITLE
Fixes to kiwi to work on kvm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 *
+!kiwi-isolinux-template.diff

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
 FROM opensuse/leap:15.0
 
-RUN zypper refresh
-RUN zypper --non-interactive dup
-RUN zypper --non-interactive install git
-RUN zypper --non-interactive install syslinux
-RUN zypper --non-interactive install xorriso
-RUN zypper --non-interactive install gfxboot
-RUN zypper --non-interactive install python3-kiwi
-RUN zypper --non-interactive install checkmedia
+RUN set -o errexit -o nounset -o xtrace \
+  ; zypper --non-interactive refresh \
+  ; zypper --non-interactive dup \
+  ; zypper --non-interactive install \
+    checkmedia \
+    gfxboot \
+    git-core \
+    patch \
+    python3-kiwi \
+    syslinux \
+    xorriso \
+  ;
+
+COPY kiwi-isolinux-template.diff /
+RUN patch -p0 -i /kiwi-isolinux-template.diff
 
 ARG DESCRIPTION
 ENV DESCRIPTION $DESCRIPTION

--- a/description/config.xml
+++ b/description/config.xml
@@ -16,6 +16,7 @@
       flags="overlay"
       image="iso"
       kernelcmdline="net.ifnames=0 swapaccount=1"
+      bootloader_console="serial"
       volid="minikube-openSUSE"/>
     <version>1.0.0</version>
     <packagemanager>zypper</packagemanager>

--- a/kiwi-isolinux-template.diff
+++ b/kiwi-isolinux-template.diff
@@ -1,0 +1,17 @@
+--- /usr/lib/python3.6/site-packages/kiwi/bootloader/template/isolinux.py    2019-07-22 21:16:22.459215665 +0000
++++ /usr/lib/python3.6/site-packages/kiwi/bootloader/template/isolinux.py 2019-07-22 21:16:46.171269970 +0000
+@@ -178,10 +178,11 @@
+         if terminal == 'serial':
+             template_data += self.serial
+             with_theme = False
+-        if with_theme:
+-            template_data += self.ui_theme
+         else:
+-            template_data += self.ui_plain
++            if with_theme:
++                template_data += self.ui_theme
++            else:
++                template_data += self.ui_plain
+         template_data += self.menu_entry
+         if failsafe:
+             template_data += self.menu_entry_failsafe


### PR DESCRIPTION
Docker-machine-driver-kvm2 does not create a video card; this causes Live CDs generated by KIWI to hang due to the use of UI.  Patch that out in the docker image we use to build to work around the issue.

This makes it possible to use minikube with the generated ISO image using KVM. Still seems to work with VirtualBox.