### PR TITLE
Allow debug output when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ ENV INTERNAL_OUTPUT /output
 
 CMD set -x \
   ; mkdir -p "${INTERNAL_OUTPUT}" \
-  ; kiwi-ng --type iso system build --description "${DESCRIPTION}" --target-dir "${INTERNAL_OUTPUT}" \
+  ; kiwi-ng ${DEBUG:+--debug --color-output} --type iso system build --description "${DESCRIPTION}" --target-dir "${INTERNAL_OUTPUT}" \
     && cp "${INTERNAL_OUTPUT}"/*.iso "${OUTPUT}"

--- a/make/build-in-docker.sh
+++ b/make/build-in-docker.sh
@@ -28,6 +28,7 @@ docker build \
 
 docker run \
   --tty --interactive --rm --privileged \
+  ${DEBUG:+--env DEBUG=1} \
   --volume "${OUTPUT}:${MOUNTED_OUTPUT}" \
   --volume "${DESCRIPTION}:${MOUNTED_DESCRIPTION}" \
   "${IMAGE_NAME}"


### PR DESCRIPTION
Set the `DEBUG` environment variable to get extra debugging output when building.  This helps track down things like the repos being busted.