### PR TITLE
Fixed Docker daemon not being accessible externally

### DIFF
--- a/description/config.sh
+++ b/description/config.sh
@@ -36,21 +36,8 @@ rm /root/virtualization-containers.key
 baseInsertService sshd
 baseInsertService chronyd
 
-mkdir -p /etc/systemd/system/docker.service.d/
-cat >> /etc/systemd/system/docker.service.d/20-extra-minikube.conf << 'EOF'
-# Extra settings that don't seem to be picked up by KVM !?
-[Unit]
-After=minikube-automount.service
-Requires=minikube-automount.service
-
-[Service]
-# DOCKER_RAMDISK disables pivot_root in Docker, using MS_MOVE instead.
-Environment=DOCKER_RAMDISK=yes
-
-LimitNOFILE=infinity
-EOF
+ln -s --no-target-directory /usr/lib/systemd /lib/systemd
 baseInsertService minikube-automount
-baseInsertService docker
 
 #======================================
 # Setup default target, multi-user.
@@ -138,7 +125,7 @@ ln -sf /mnt/sda1/var/lib/localkube /var/lib/localkube
 # Boot symlinks.
 #--------------------------------------
 
-ln -sf $(readlink /boot/vmlinuz) /boot/bzimage
+ln -sf "$(readlink /boot/vmlinuz)" /boot/bzimage
 
 #--------------------------------------
 

--- a/description/config.xml
+++ b/description/config.xml
@@ -21,7 +21,7 @@
       kernelcmdline="net.ifnames=0 swapaccount=1"
       bootloader_console="serial"
       volid="minikube-openSUSE"/>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <packagemanager>zypper</packagemanager>
     <locale>en_US</locale>
     <keytable>us</keytable>


### PR DESCRIPTION
Given that it's different how the KVM and Virtualbox machines are
created, the docker.service containing the correct configuration end up
being in different places.

With the symlink introduced in this commit, the problem is solved
because systemd will pick the correct one in both cases.