### PR TITLE
/etc/sysctl.d: Bump some limits

### DIFF
--- a/description/root/etc/sysctl.d/10-limits.conf
+++ b/description/root/etc/sysctl.d/10-limits.conf
@@ -1,0 +1,5 @@
+fs.file-max = 4194304
+fs.inotify.max_user_instances = 1024
+fs.inotify.max_user_watches = 1048576
+
+vm.min_free_kbytes = 65536


### PR DESCRIPTION
The VM appears to have issues staying up overnight; usually I come to a machine using 100% CPU (over multiple cores) and completely unresponsive over SSH.

Bump up vm.min_free_kbytes as StackOverflow seems to think this helps. It seemed to in my limited tested (lasted over a weekend).

Also bump up max fileno and inotify limits, as sometimes we seem to run out when watching logs.

Fixes #13