### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/description/config.sh
+++ b/description/config.sh
@@ -65,6 +65,10 @@ suseConfig
 printf "%b" "
 UseDNS no
 GSSAPIAuthentication no
+MaxSessions 200
+UsePAM no
+X11Forwarding no
+PrintLastLog no
 " >> /etc/ssh/sshd_config
 
 #======================================
@@ -89,6 +93,15 @@ root ALL=(ALL) ALL
 
 echo "" >> /home/docker/.bashrc
 echo 'export PATH="/bin:/sbin:/usr/bin:/usr/sbin"' >> /home/docker/.bashrc
+
+#======================================
+# Extra docker configuration
+#--------------------------------------
+perl -p -i -e '
+# Recommended by minikube
+# https://kubernetes.io/docs/setup/production-environment/container-runtimes/
+s@^(DOCKER_OPTS=".*?) *(")@$1 --exec-opt=native.cgroupdriver=systemd $2@
+' /etc/sysconfig/docker
 
 #======================================
 # Disable multi kernel.

--- a/description/config.xml
+++ b/description/config.xml
@@ -21,7 +21,7 @@
       kernelcmdline="net.ifnames=0 swapaccount=1 console=ttyS0"
       bootloader_console="serial"
       volid="minikube-openSUSE"/>
-    <version>0.1.5</version>
+    <version>0.1.6</version>
     <packagemanager>zypper</packagemanager>
     <locale>en_US</locale>
     <keytable>us</keytable>
@@ -80,18 +80,15 @@
     <package name="openSUSE-release"/>
     <package name="udev"/>
   </packages>
-  <repository
-    alias="OSS Updates"
-    imageinclude="false"
-    type="rpm-md"
-  >
+  <!-- This is only available for Leap 15.1 and above
+  <repository type="rpm-md" alias="kiwi" priority="1">
+    <source path="obs://Virtualization:Appliances:Builder/openSUSE_Leap_&version;"/>
+  </repository>
+  -->
+  <repository type="rpm-md" imageinclude="true" alias="updates">
     <source path="obs://openSUSE:Leap:&version;:Update/standard"/>
   </repository>
-  <repository
-    alias="OSS"
-    imageinclude="false"
-    type="rpm-md"
-  >
+  <repository type="rpm-md" imageinclude="true" alias="oss">
     <source path="obs://openSUSE:Leap:&version;/standard"/>
   </repository>
 </image>

--- a/description/root/etc/systemd/system/docker.service.d/20-limits.conf
+++ b/description/root/etc/systemd/system/docker.service.d/20-limits.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE=infinity

--- a/description/root/etc/systemd/system/sshd.service.d/10-lastlog.conf
+++ b/description/root/etc/systemd/system/sshd.service.d/10-lastlog.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPre=/usr/bin/touch /var/log/btmp
+ExecStartPre=/usr/bin/touch /var/log/lastlog

--- a/description/root/etc/zypp/repos.d/oss.repo
+++ b/description/root/etc/zypp/repos.d/oss.repo
@@ -1,8 +1,0 @@
-[oss]
-name=Main Repository (OSS)
-enabled=1
-autorefresh=1
-baseurl=http://download.opensuse.org/distribution/leap/15.0/repo/oss/
-path=/
-type=yast2
-keeppackages=0

--- a/description/root/etc/zypp/repos.d/updates.repo
+++ b/description/root/etc/zypp/repos.d/updates.repo
@@ -1,8 +1,0 @@
-[updates]
-name=Main Update Repository
-enabled=1
-autorefresh=1
-baseurl=http://download.opensuse.org/update/leap/15.0/oss
-path=/
-type=rpm-md
-keeppackages=0


### PR DESCRIPTION
- No need for explicit zypper config files; just make kiwi keep repos
- Extra sshd configuration to reduce warnings in journald
- Switch docker cgroup driver to systemd per kubernetes documentation
- Bump docker file limits

Unfortunately, trying to switch to openSUSE Leap 15.1 appears to introduce problems with ssh multiplexing.